### PR TITLE
vec/api: fix insert for index == len

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -755,7 +755,7 @@ where
 	///
 	/// [`self.len()`]: Self::len
 	pub fn set(&mut self, index: usize, value: bool) {
-		self.assert_in_bounds(index);
+		self.assert_in_bounds(index, 0..self.len());
 		unsafe {
 			self.set_unchecked(index, value);
 		}
@@ -815,7 +815,7 @@ where
 	/// [`self.len()`]: Self::len
 	pub fn set_aliased(&self, index: usize, value: bool)
 	where T: radium::Radium {
-		self.assert_in_bounds(index);
+		self.assert_in_bounds(index, 0..self.len());
 		unsafe {
 			self.set_aliased_unchecked(index, value);
 		}
@@ -2348,21 +2348,22 @@ where
 		BitSpan::from_bitslice_ptr_mut(self)
 	}
 
-	/// Asserts that `index` is less than [`self.len()`].
+	/// Asserts that `index` is not out of `bounds`.
 	///
 	/// # Parameters
 	///
 	/// - `&self`
 	/// - `index`: The index to test against [`self.len()`].
+	/// - `bounds`: Bounds to check.
 	///
 	/// # Panics
 	///
-	/// This method panics if `index` is not less than `self.len()`.
-	///
-	/// [`self.len()`]: Self::len
-	pub(crate) fn assert_in_bounds(&self, index: usize) {
-		let len = self.len();
-		assert!(index < len, "Index out of range: {} >= {}", index, len);
+	/// This method panics if `bounds` doesn't contain the `index`.
+	pub(crate) fn assert_in_bounds<R>(&self, index: usize, bounds: R)
+	where
+		R: RangeBounds<usize>,
+	{
+		assert!(bounds.contains(&index), "Index {} out of range: {:?}", index, bounds.end_bound());
 	}
 
 	/// Marks an immutable slice as referring to aliased memory region.

--- a/src/slice/api.rs
+++ b/src/slice/api.rs
@@ -1251,6 +1251,12 @@ where
 	///   left.set(1, true);
 	///   right.set(1, false);
 	/// }
+	/// {
+	///   let mut v = bits![mut 0; 0];
+	///   let (left, right) = v.split_at_mut(0);
+	///   assert!(left.is_empty());
+	///   assert!(right.is_empty());
+	/// }
 	/// assert_eq!(v, bits![0, 1, 0, 0, 1, 1]);
 	/// ```
 	///
@@ -1265,7 +1271,7 @@ where
 		&mut self,
 		mid: usize,
 	) -> (&mut BitSlice<O, T::Alias>, &mut BitSlice<O, T::Alias>) {
-		self.assert_in_bounds(mid, 0..self.len());
+		self.assert_in_bounds(mid, 0..=self.len());
 		unsafe { self.split_at_unchecked_mut(mid) }
 	}
 

--- a/src/slice/api.rs
+++ b/src/slice/api.rs
@@ -576,8 +576,8 @@ where
 	/// ```
 	#[inline]
 	pub fn swap(&mut self, a: usize, b: usize) {
-		self.assert_in_bounds(a);
-		self.assert_in_bounds(b);
+		self.assert_in_bounds(a, 0..self.len());
+		self.assert_in_bounds(b, 0..self.len());
 		unsafe {
 			self.swap_unchecked(a, b);
 		}
@@ -1265,7 +1265,7 @@ where
 		&mut self,
 		mid: usize,
 	) -> (&mut BitSlice<O, T::Alias>, &mut BitSlice<O, T::Alias>) {
-		self.assert_in_bounds(mid);
+		self.assert_in_bounds(mid, 0..self.len());
 		unsafe { self.split_at_unchecked_mut(mid) }
 	}
 

--- a/src/vec/api.rs
+++ b/src/vec/api.rs
@@ -588,7 +588,7 @@ where
 	/// ```
 	#[inline]
 	pub fn swap_remove(&mut self, index: usize) -> bool {
-		self.assert_in_bounds(index);
+		self.assert_in_bounds(index, 0..self.len());
 		let last = self.len() - 1;
 		unsafe {
 			self.swap_unchecked(index, last);
@@ -621,8 +621,7 @@ where
 	/// ```
 	#[inline]
 	pub fn insert(&mut self, index: usize, value: bool) {
-		// we allow for index == len
-		self.assert_in_bounds(index.saturating_sub(1));
+		self.assert_in_bounds(index, 0..=self.len());
 		self.push(value);
 		unsafe { self.get_unchecked_mut(index ..) }.rotate_right(1);
 	}
@@ -649,7 +648,7 @@ where
 	/// ```
 	#[inline]
 	pub fn remove(&mut self, index: usize) -> bool {
-		self.assert_in_bounds(index);
+		self.assert_in_bounds(index, 0..self.len());
 		let last = self.len() - 1;
 		unsafe {
 			self.get_unchecked_mut(index ..).rotate_left(1);

--- a/src/vec/api.rs
+++ b/src/vec/api.rs
@@ -614,14 +614,15 @@ where
 	/// use bitvec::prelude::*;
 	///
 	/// let mut bv = bitvec![0; 5];
-	/// bv.insert(4, true);
-	/// assert_eq!(bv, bits![0, 0, 0, 0, 1, 0]);
+	/// bv.insert(5, true);
+	/// assert_eq!(bv, bits![0, 0, 0, 0, 0, 1]);
 	/// bv.insert(2, true);
-	/// assert_eq!(bv, bits![0, 0, 1, 0, 0, 1, 0]);
+	/// assert_eq!(bv, bits![0, 0, 1, 0, 0, 0, 1]);
 	/// ```
 	#[inline]
 	pub fn insert(&mut self, index: usize, value: bool) {
-		self.assert_in_bounds(index);
+		// we allow for index == len
+		self.assert_in_bounds(index.saturating_sub(1));
 		self.push(value);
 		unsafe { self.get_unchecked_mut(index ..) }.rotate_right(1);
 	}

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -213,6 +213,10 @@ fn iterators() {
 
 #[test]
 fn misc() {
+	let mut bv = bitvec![0; 0];
+	bv.insert(0, true);
+	assert_eq!(bv, bits![1]);
+
 	let mut bv = bitvec![1; 10];
 	bv.truncate(20);
 	assert_eq!(bv, bits![1; 10]);


### PR DESCRIPTION
The docs says "Panics if `index > len`", not `>=`.