### PR TITLE
Fix insufficiently precise dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ radium = "0.6"
 tap = "1"
 
 [dependencies.funty]
-version = "1"
+version = "1.2"
 default-features = false
 
 [dependencies.serde]


### PR DESCRIPTION
The version of `funty` required matches `1.0`, but this version does not have the `IsNumber::BITS` constant required by `bitvec`. This PR more precisely specifies the required version.

This could be changed to `^1.2`.