### PR TITLE
Fix ambiguous associated type usage on top of 0.20

### DIFF
--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -119,7 +119,7 @@ are dominant."
 		println!("{:?}", bs.domain());
 		println!("Show the bits in memory");
 		for elt in bs.domain() {
-			println!("{:0w$b} ", elt, w = T::Mem::BITS as usize);
+			println!("{:0w$b} ", elt, w = <T::Mem as BitMemory>::BITS as usize);
 		}
 		println!();
 	}

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -225,7 +225,7 @@ where
 		let mut boxed = ManuallyDrop::new(boxed);
 
 		BitPtr::from_mut_slice(&mut boxed[..])
-			.span(boxed.len() * T::Mem::BITS as usize)
+			.span(boxed.len() * <T::Mem as BitMemory>::BITS as usize)
 			.map(|bitspan| Self { bitspan })
 			.map_err(|_| ManuallyDrop::into_inner(boxed))
 	}
@@ -438,7 +438,7 @@ where
 		let (_, head, bits) = bp.raw_parts();
 		let head = head.value() as usize;
 		let tail = head + bits;
-		let full = crate::mem::elts::<T::Mem>(tail) * T::Mem::BITS as usize;
+		let full = crate::mem::elts::<T::Mem>(tail) * <T::Mem as BitMemory>::BITS as usize;
 		unsafe {
 			bp.set_head(BitIdx::ZERO);
 			bp.set_len(full);

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -231,7 +231,7 @@ macro_rules! bit_domain {
 				let bitspan = slice.as_bitspan();
 				let h = bitspan.head();
 				let (e, t) = h.span(bitspan.len());
-				let w = T::Mem::BITS;
+				let w = <T::Mem as BitMemory>::BITS;
 
 				match (h.value(), e, t.value()) {
 					(_, 0, _) => Self::empty(),
@@ -258,7 +258,7 @@ macro_rules! bit_domain {
 			) -> Self {
 				let (head, rest) = bit_domain!(split $($m)?
 					slice,
-					(T::Mem::BITS - head.value()) as usize,
+					(<T::Mem as BitMemory>::BITS - head.value()) as usize,
 				);
 				let (body, tail) = bit_domain!(split $($m)?
 					rest,
@@ -289,7 +289,7 @@ macro_rules! bit_domain {
 			) -> Self {
 				let (head, rest) = bit_domain!(split $($m)?
 					slice,
-					(T::Mem::BITS - head.value()) as usize,
+					(<T::Mem as BitMemory>::BITS - head.value()) as usize,
 				);
 				let (head, body) = (
 					bit_domain!(retype $($m)? head),
@@ -537,7 +537,7 @@ macro_rules! domain {
 				let head = bitspan.head();
 				let elts = bitspan.elements();
 				let tail = bitspan.tail();
-				let bits = T::Mem::BITS;
+				let bits = <T::Mem as BitMemory>::BITS;
 				let base = bitspan.address().to_const() as *const _;
 				match (head.value(), elts, tail.value()) {
 					(_, 0, _) => Self::empty(),

--- a/src/field.rs
+++ b/src/field.rs
@@ -701,8 +701,8 @@ where T: BitStore
 					As a const-expression, this branch folds at compile-time to
 					conditionally remove or retain the instruction.
 					*/
-					if M::BITS > T::Mem::BITS {
-						accum <<= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						accum <<= <T::Mem as BitMemory>::BITS;
 					}
 					accum |= resize::<T::Mem, M>(elem);
 				}
@@ -780,8 +780,8 @@ where T: BitStore
 				}
 
 				for elem in body.iter().map(BitStore::load_value) {
-					if M::BITS > T::Mem::BITS {
-						accum <<= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						accum <<= <T::Mem as BitMemory>::BITS;
 					}
 					accum |= resize::<T::Mem, M>(elem);
 				}
@@ -840,8 +840,8 @@ where T: BitStore
 
 				for elem in body.iter_mut() {
 					elem.store_value(resize(value));
-					if M::BITS > T::Mem::BITS {
-						value >>= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						value >>= <T::Mem as BitMemory>::BITS;
 					}
 				}
 
@@ -895,8 +895,8 @@ where T: BitStore
 
 				for elem in body.iter_mut().rev() {
 					elem.store_value(resize(value));
-					if M::BITS > T::Mem::BITS {
-						value >>= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						value >>= <T::Mem as BitMemory>::BITS;
 					}
 				}
 
@@ -969,7 +969,7 @@ where T: BitStore
 			Domain::Enclave { head, elem, tail } => get::<T, M>(
 				elem,
 				Msb0::mask(head, tail),
-				T::Mem::BITS - tail.value(),
+				<T::Mem as BitMemory>::BITS - tail.value(),
 			),
 			Domain::Region { head, body, tail } => {
 				let mut accum = M::ZERO;
@@ -978,19 +978,19 @@ where T: BitStore
 					accum = get::<T, M>(
 						elem,
 						Msb0::mask(None, tail),
-						T::Mem::BITS - tail.value(),
+						<T::Mem as BitMemory>::BITS - tail.value(),
 					);
 				}
 
 				for elem in body.iter().rev().map(BitStore::load_value) {
-					if M::BITS > T::Mem::BITS {
-						accum <<= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						accum <<= <T::Mem as BitMemory>::BITS;
 					}
 					accum |= resize::<T::Mem, M>(elem);
 				}
 
 				if let Some((head, elem)) = head {
-					accum <<= T::Mem::BITS - head.value();
+					accum <<= <T::Mem as BitMemory>::BITS - head.value();
 					accum |= get::<T, M>(elem, Msb0::mask(head, None), 0);
 				}
 
@@ -1052,7 +1052,7 @@ where T: BitStore
 			Domain::Enclave { head, elem, tail } => get::<T, M>(
 				elem,
 				Msb0::mask(head, tail),
-				T::Mem::BITS - tail.value(),
+				<T::Mem as BitMemory>::BITS - tail.value(),
 			),
 			Domain::Region { head, body, tail } => {
 				let mut accum = M::ZERO;
@@ -1062,8 +1062,8 @@ where T: BitStore
 				}
 
 				for elem in body.iter().map(BitStore::load_value) {
-					if M::BITS > T::Mem::BITS {
-						accum <<= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						accum <<= <T::Mem as BitMemory>::BITS;
 					}
 					accum |= resize::<T::Mem, M>(elem);
 				}
@@ -1074,7 +1074,7 @@ where T: BitStore
 					accum |= get::<T, M>(
 						elem,
 						Msb0::mask(None, tail),
-						T::Mem::BITS - width,
+						<T::Mem as BitMemory>::BITS - width,
 					);
 				}
 
@@ -1117,18 +1117,18 @@ where T: BitStore
 				elem,
 				value,
 				Msb0::mask(head, tail),
-				T::Mem::BITS - tail.value(),
+				<T::Mem as BitMemory>::BITS - tail.value(),
 			),
 			DomainMut::Region { head, body, tail } => {
 				if let Some((head, elem)) = head {
 					set::<T, M>(elem, value, Msb0::mask(head, None), 0);
-					value >>= T::Mem::BITS - head.value();
+					value >>= <T::Mem as BitMemory>::BITS - head.value();
 				}
 
 				for elem in body.iter_mut() {
 					elem.store_value(resize(value));
-					if M::BITS > T::Mem::BITS {
-						value >>= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						value >>= <T::Mem as BitMemory>::BITS;
 					}
 				}
 
@@ -1137,7 +1137,7 @@ where T: BitStore
 						elem,
 						value,
 						Msb0::mask(None, tail),
-						T::Mem::BITS - tail.value(),
+						<T::Mem as BitMemory>::BITS - tail.value(),
 					);
 				}
 			},
@@ -1178,7 +1178,7 @@ where T: BitStore
 				elem,
 				value,
 				Msb0::mask(head, tail),
-				T::Mem::BITS - tail.value(),
+				<T::Mem as BitMemory>::BITS - tail.value(),
 			),
 			DomainMut::Region { head, body, tail } => {
 				if let Some((elem, tail)) = tail {
@@ -1186,15 +1186,15 @@ where T: BitStore
 						elem,
 						value,
 						Msb0::mask(None, tail),
-						T::Mem::BITS - tail.value(),
+						<T::Mem as BitMemory>::BITS - tail.value(),
 					);
 					value >>= tail.value();
 				}
 
 				for elem in body.iter_mut().rev() {
 					elem.store_value(resize(value));
-					if M::BITS > T::Mem::BITS {
-						value >>= T::Mem::BITS;
+					if <M as BitMemory>::BITS > <T::Mem as BitMemory>::BITS {
+						value >>= <T::Mem as BitMemory>::BITS;
 					}
 				}
 
@@ -1298,11 +1298,11 @@ where
 /// [`M::BITS`]: crate::mem::BitMemory::BITS
 fn check<M>(action: &'static str, len: usize)
 where M: BitMemory {
-	if !(1 ..= M::BITS as usize).contains(&len) {
+	if !(1 ..= <M as BitMemory>::BITS as usize).contains(&len) {
 		panic!(
 			"Cannot {} {} bits from a {}-bit region",
 			action,
-			M::BITS,
+			<M as BitMemory>::BITS,
 			len,
 		);
 	}

--- a/src/index.rs
+++ b/src/index.rs
@@ -40,7 +40,7 @@ operations, and is used to create selection masks [`BitSel`] and [`BitMask`].
 !*/
 
 use crate::{
-	mem::BitRegister,
+	mem::{BitRegister, BitMemory},
 	order::BitOrder,
 };
 
@@ -141,7 +141,7 @@ where R: BitRegister
 	/// [`Self::LAST`]: Self::LAST
 	/// [`Self::ZERO`]: Self::ZERO
 	pub fn new(value: u8) -> Result<Self, BitIdxError<R>> {
-		if value >= R::BITS {
+		if value >= <R as BitMemory>::BITS {
 			return Err(BitIdxError::new(value));
 		}
 		Ok(unsafe { Self::new_unchecked(value) })
@@ -168,10 +168,10 @@ where R: BitRegister
 	/// [`Self::ZERO`]: Self::ZERO
 	pub unsafe fn new_unchecked(value: u8) -> Self {
 		debug_assert!(
-			value < R::BITS,
+			value < <R as BitMemory>::BITS,
 			"Bit index {} cannot exceed type width {}",
 			value,
-			R::BITS,
+			<R as BitMemory>::BITS,
 		);
 		Self {
 			idx: value,
@@ -209,7 +209,7 @@ where R: BitRegister
 		let next = self.idx + 1;
 		(
 			unsafe { Self::new_unchecked(next & R::MASK) },
-			next == R::BITS,
+			next == <R as BitMemory>::BITS,
 		)
 	}
 
@@ -355,7 +355,7 @@ where R: BitRegister
 		if !ovf {
 			//  If `far` is in the origin element, then the jump moves zero
 			//  elements and produces `far` as an absolute index directly.
-			if (0 .. R::BITS as isize).contains(&far) {
+			if (0 .. <R as BitMemory>::BITS as isize).contains(&far) {
 				(0, unsafe { Self::new_unchecked(far as u8) })
 			}
 			/* Otherwise, downshift the bit distance to compute the number of
@@ -480,10 +480,10 @@ where R: BitRegister
 	/// Debug builds panic when `value` is a valid index for `R`.
 	pub(crate) fn new(value: u8) -> Self {
 		debug_assert!(
-			value >= R::BITS,
+			value >= <R as BitMemory>::BITS,
 			"Bit index {} is valid for type width {}",
 			value,
-			R::BITS
+			<R as BitMemory>::BITS
 		);
 		Self {
 			err: value,
@@ -516,7 +516,7 @@ where R: BitRegister
 			"The value {} is too large to index into {} ({} bits)",
 			self.err,
 			any::type_name::<R>(),
-			R::BITS
+			<R as BitMemory>::BITS
 		)
 	}
 }
@@ -577,7 +577,7 @@ where R: BitRegister
 {
 	/// The inclusive maximum tail within an element `R`.
 	pub(crate) const LAST: Self = Self {
-		end: R::BITS,
+		end: <R as BitMemory>::BITS,
 		_ty: PhantomData,
 	};
 	/// The inclusive minimum tail within an element `R`.
@@ -601,7 +601,7 @@ where R: BitRegister
 	/// [`Self::LAST`]: Self::LAST
 	/// [`Self::ZERO`]: Self::ZERO
 	pub fn new(value: u8) -> Option<Self> {
-		if value > R::BITS {
+		if value > <R as BitMemory>::BITS {
 			return None;
 		}
 		Some(unsafe { Self::new_unchecked(value) })
@@ -628,10 +628,10 @@ where R: BitRegister
 	/// [`Self::ZERO`]: Self::ZERO
 	pub(crate) unsafe fn new_unchecked(value: u8) -> Self {
 		debug_assert!(
-			value <= R::BITS,
+			value <= <R as BitMemory>::BITS,
 			"Bit tail {} cannot exceed type width {}",
 			value,
-			R::BITS,
+			<R as BitMemory>::BITS,
 		);
 		Self {
 			end: value,
@@ -709,7 +709,7 @@ where R: BitRegister
 		let val = self.end;
 
 		let head = val & R::MASK;
-		let bits_in_head = (R::BITS - head) as usize;
+		let bits_in_head = (<R as BitMemory>::BITS - head) as usize;
 
 		if len <= bits_in_head {
 			return (1, unsafe { Self::new_unchecked(head + len as u8) });
@@ -810,7 +810,7 @@ where R: BitRegister
 	/// This returns `Some(value)` when it is in the valid range `0 .. R::BITS`,
 	/// and `None` when it is not.
 	pub fn new(value: u8) -> Option<Self> {
-		if value >= R::BITS {
+		if value >= <R as BitMemory>::BITS {
 			return None;
 		}
 		Some(unsafe { Self::new_unchecked(value) })
@@ -835,10 +835,10 @@ where R: BitRegister
 	/// `value`.
 	pub unsafe fn new_unchecked(value: u8) -> Self {
 		debug_assert!(
-			value < R::BITS,
+			value < <R as BitMemory>::BITS,
 			"Bit position {} cannot exceed type width {}",
 			value,
-			R::BITS,
+			<R as BitMemory>::BITS,
 		);
 		Self {
 			pos: value,
@@ -994,7 +994,7 @@ where R: BitRegister
 			value.count_ones() == 1,
 			"Selections are required to have exactly one set bit: {:0>1$b}",
 			value,
-			R::BITS as usize,
+			<R as BitMemory>::BITS as usize,
 		);
 		Self { sel: value }
 	}
@@ -1025,7 +1025,7 @@ impl<R> Binary for BitSel<R>
 where R: BitRegister
 {
 	fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-		write!(fmt, "{:0>1$b}", self.sel, R::BITS as usize)
+		write!(fmt, "{:0>1$b}", self.sel, <R as BitMemory>::BITS as usize)
 	}
 }
 
@@ -1165,7 +1165,7 @@ impl<R> Binary for BitMask<R>
 where R: BitRegister
 {
 	fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-		write!(fmt, "{:0>1$b}", self.mask, R::BITS as usize)
+		write!(fmt, "{:0>1$b}", self.mask, <R as BitMemory>::BITS as usize)
 	}
 }
 

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -44,11 +44,11 @@ pub trait BitMemory: IsUnsigned + seal::Sealed {
 	const BITS: u8 = mem::size_of::<Self>() as u8 * 8;
 
 	/// The number of bits required to store an index in the range `0 .. BITS`.
-	const INDX: u8 = Self::BITS.trailing_zeros() as u8;
+	const INDX: u8 = <Self as BitMemory>::BITS.trailing_zeros() as u8;
 
 	/// A mask over all bits that can be used as an index within the element.
 	/// This is the value with the least significant `INDX`-many bits set high.
-	const MASK: u8 = Self::BITS - 1;
+	const MASK: u8 = <Self as BitMemory>::BITS - 1;
 }
 
 /** Description of a processor register.

--- a/src/order.rs
+++ b/src/order.rs
@@ -30,7 +30,7 @@ use crate::{
 		BitSel,
 		BitTail,
 	},
-	mem::BitRegister,
+	mem::{BitRegister, BitMemory},
 };
 
 /** An ordering over a register.
@@ -288,7 +288,7 @@ unsafe impl BitOrder for Lsb0 {
 			upto
 		);
 		let ct = upto - from;
-		if ct == R::BITS {
+		if ct == <R as BitMemory>::BITS {
 			return BitMask::ALL;
 		}
 		//  1. Set all bits in the mask high
@@ -336,7 +336,7 @@ unsafe impl BitOrder for Msb0 {
 			upto
 		);
 		let ct = upto - from;
-		if ct == R::BITS {
+		if ct == <R as BitMemory>::BITS {
 			return BitMask::ALL;
 		}
 		//  1. Set all bits in the mask high.
@@ -447,7 +447,7 @@ where
 	let oname = type_name::<O>();
 	let mname = type_name::<R>();
 
-	for n in 0 .. R::BITS {
+	for n in 0 .. <R as BitMemory>::BITS {
 		//  Wrap the counter as an index.
 		let idx = unsafe { BitIdx::<R>::new_unchecked(n) };
 
@@ -466,14 +466,14 @@ where
 
 		//  If the computed position exceeds the valid range, fail.
 		assert!(
-			pos.value() < R::BITS,
+			pos.value() < <R as BitMemory>::BITS,
 			"Error when verifying the implementation of `BitOrder` for `{}`: \
 			 Index {} produces a bit position ({}) that exceeds the type width \
 			 {}",
 			oname,
 			n,
 			pos.value(),
-			R::BITS,
+			<R as BitMemory>::BITS,
 		);
 
 		//  Check `O`’s implementation of `select`

--- a/src/ptr/span.rs
+++ b/src/ptr/span.rs
@@ -470,8 +470,8 @@ where
 				//  slices of the original type to merge with `head` and `tail`.
 				let (l, c, r) = body.align_to::<U::Mem>();
 
-				let t_bits = T::Mem::BITS as usize;
-				let u_bits = U::Mem::BITS as usize;
+				let t_bits = <T::Mem as BitMemory>::BITS as usize;
+				let u_bits = <U::Mem as BitMemory>::BITS as usize;
 
 				let l_bits = l.len() * t_bits;
 				let c_bits = c.len() * u_bits;
@@ -1009,7 +1009,7 @@ where
 		let (addr_b, head_b, bits_b) = other.raw_parts();
 		//  Since ::BITS is an associated const, the compiler will automatically
 		//  replace the entire function with `false` when the types don’t match.
-		T1::Mem::BITS == T2::Mem::BITS
+		<T1::Mem as BitMemory>::BITS == <T2::Mem as BitMemory>::BITS
 			&& addr_a.value() == addr_b.value()
 			&& head_a.value() == head_b.value()
 			&& bits_a == bits_b

--- a/src/serdes.rs
+++ b/src/serdes.rs
@@ -229,7 +229,7 @@ where
 		let bits = cmp::min(
 			bits,
 			data.len()
-				.saturating_mul(T::Mem::BITS as usize)
+				.saturating_mul(<T::Mem as BitMemory>::BITS as usize)
 				.saturating_sub(head as usize),
 		);
 		//  Assemble a pointer to the start bit,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -489,7 +489,7 @@ where
 	/// [`BitView`]: crate::view::BitView
 	/// [`.view_bits::<O>()`]: crate::view::BitView::view_bits
 	pub fn from_element(elem: &T) -> &Self {
-		unsafe { BitPtr::from_ref(elem).span_unchecked(T::Mem::BITS as usize) }
+		unsafe { BitPtr::from_ref(elem).span_unchecked(<T::Mem as BitMemory>::BITS as usize) }
 			.to_bitslice_ref()
 	}
 
@@ -526,7 +526,7 @@ where
 	/// [`BitView`]: crate::view::BitView
 	/// [`.view_bits_mut::<O>()`]: crate::view::BitView::view_bits_mut
 	pub fn from_element_mut(elem: &mut T) -> &mut Self {
-		unsafe { BitPtr::from_mut(elem).span_unchecked(T::Mem::BITS as usize) }
+		unsafe { BitPtr::from_mut(elem).span_unchecked(<T::Mem as BitMemory>::BITS as usize) }
 			.to_bitslice_mut()
 	}
 
@@ -574,7 +574,7 @@ where
 		//  an inclusive cap. This is also pretty much impossible to hit.
 		if elts >= Self::MAX_ELTS {
 			return Err(BitSpanError::TooLong(
-				elts.saturating_mul(T::Mem::BITS as usize),
+				elts.saturating_mul(<T::Mem as BitMemory>::BITS as usize),
 			));
 		}
 		Ok(unsafe { Self::from_slice_unchecked(slice) })
@@ -642,7 +642,7 @@ where
 		let elts = slice.len();
 		if elts >= Self::MAX_ELTS {
 			return Err(BitSpanError::TooLong(
-				elts.saturating_mul(T::Mem::BITS as usize),
+				elts.saturating_mul(<T::Mem as BitMemory>::BITS as usize),
 			));
 		}
 		Ok(unsafe { Self::from_slice_unchecked_mut(slice) })
@@ -662,7 +662,7 @@ where
 	/// [`MAX_ELTS`]: Self::MAX_ELTS
 	/// [`::from_slice()`]: Self::from_slice
 	pub unsafe fn from_slice_unchecked(slice: &[T]) -> &Self {
-		let bits = slice.len().wrapping_mul(T::Mem::BITS as usize);
+		let bits = slice.len().wrapping_mul(<T::Mem as BitMemory>::BITS as usize);
 		BitPtr::from_slice(slice)
 			.span_unchecked(bits)
 			.to_bitslice_ref()
@@ -682,7 +682,7 @@ where
 	/// [`MAX_ELTS`]: Self::MAX_ELTS
 	/// [`::from_slice_mut()`]: Self::from_slice_mut
 	pub unsafe fn from_slice_unchecked_mut(slice: &mut [T]) -> &mut Self {
-		let bits = slice.len().wrapping_mul(T::Mem::BITS as usize);
+		let bits = slice.len().wrapping_mul(<T::Mem as BitMemory>::BITS as usize);
 		BitPtr::from_mut_slice(slice)
 			.span_unchecked(bits)
 			.to_bitslice_mut()

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -420,7 +420,7 @@ fn unspecialized() {
 			BitIdx,
 			BitPos,
 		},
-		mem::BitRegister,
+		mem::{BitRegister, BitMemory},
 		prelude::*,
 	};
 
@@ -429,7 +429,7 @@ fn unspecialized() {
 	unsafe impl BitOrder for Swizzle {
 		fn at<R>(index: BitIdx<R>) -> BitPos<R>
 		where R: BitRegister {
-			match R::BITS {
+			match <R as BitMemory>::BITS {
 				8 => BitPos::new(index.value() ^ 0b100).unwrap(),
 				16 => BitPos::new(index.value() ^ 0b1100).unwrap(),
 				32 => BitPos::new(index.value() ^ 0b11100).unwrap(),

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -426,7 +426,7 @@ where
 		let capacity = vec.capacity();
 
 		BitPtr::from_mut_slice(vec.as_mut_slice())
-			.span(vec.len() * T::Mem::BITS as usize)
+			.span(vec.len() * <T::Mem as BitMemory>::BITS as usize)
 			.map(|bitspan| Self { bitspan, capacity })
 			.map_err(|_| ManuallyDrop::into_inner(vec))
 	}

--- a/src/vec/api.rs
+++ b/src/vec/api.rs
@@ -283,7 +283,7 @@ where
 	#[inline]
 	pub fn capacity(&self) -> usize {
 		self.capacity
-			.checked_mul(T::Mem::BITS as usize)
+			.checked_mul(<T::Mem as BitMemory>::BITS as usize)
 			.expect("Bit-Vector capacity exceeded")
 			//  Don’t forget to subtract any dead bits in the front of the base!
 			//  This has to be saturating, becase a non-zero head on a zero

--- a/src/view.rs
+++ b/src/view.rs
@@ -203,7 +203,7 @@ macro_rules! view_bits {
 			where O: BitOrder {
 				unsafe { from_raw_parts_unchecked(
 					BitPtr::from_slice(&self[..]),
-					$n * T::Mem::BITS as usize,
+					$n * <T::Mem as BitMemory>::BITS as usize,
 				) }
 			}
 
@@ -212,7 +212,7 @@ macro_rules! view_bits {
 			where O: BitOrder {
 				unsafe { from_raw_parts_unchecked_mut(
 					BitPtr::from_mut_slice(&mut self[..]),
-					$n * T::Mem::BITS as usize,
+					$n * <T::Mem as BitMemory>::BITS as usize,
 				) }
 			}
 

--- a/tests/foreign_order.rs
+++ b/tests/foreign_order.rs
@@ -12,7 +12,7 @@ use bitvec::{
 		BitIdx,
 		BitPos,
 	},
-	mem::BitRegister,
+	mem::{BitRegister, BitMemory},
 	prelude::*,
 };
 
@@ -21,7 +21,7 @@ pub struct Swizzle;
 unsafe impl BitOrder for Swizzle {
 	fn at<R>(index: BitIdx<R>) -> BitPos<R>
 	where R: BitRegister {
-		match R::BITS {
+		match <R as BitMemory>::BITS {
 			8 => BitPos::new(index.value() ^ 0b100).unwrap(),
 			16 => BitPos::new(index.value() ^ 0b1100).unwrap(),
 			32 => BitPos::new(index.value() ^ 0b11100).unwrap(),


### PR DESCRIPTION
funty 1.2 adds an associated const which conflicts with `BitMemory::BITS` on type inference.
This PR resolve the ambiguity by expliciting trait to use.

This is meant to be based on 0.20 but there is no branch (thus the missleading conflicts)

Also could we release a 0.20.2 with this patch ?