### PR TITLE
Fix edge case for {leading,trailing}_{zero,one}

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1242,7 +1242,7 @@ where
 	/// ```
 	#[inline]
 	pub fn leading_ones(&self) -> usize {
-		self.first_zero().unwrap_or_default()
+		self.first_zero().unwrap_or(self.len())
 	}
 
 	/// Counts the number of bits from the start of the bit-slice to the first
@@ -1261,7 +1261,7 @@ where
 	/// ```
 	#[inline]
 	pub fn leading_zeros(&self) -> usize {
-		self.first_one().unwrap_or_default()
+		self.first_one().unwrap_or(self.len())
 	}
 
 	/// Counts the number of bits from the end of the bit-slice to the last bit
@@ -1280,9 +1280,10 @@ where
 	/// ```
 	#[inline]
 	pub fn trailing_ones(&self) -> usize {
+		let len = self.len();
 		self.last_zero()
-			.map(|idx| self.len() - 1 - idx)
-			.unwrap_or_default()
+			.map(|idx| len - 1 - idx)
+			.unwrap_or(len)
 	}
 
 	/// Counts the number of bits from the end of the bit-slice to the last bit
@@ -1301,9 +1302,10 @@ where
 	/// ```
 	#[inline]
 	pub fn trailing_zeros(&self) -> usize {
+		let len = self.len();
 		self.last_one()
-			.map(|idx| self.len() - 1 - idx)
-			.unwrap_or_default()
+			.map(|idx| len - 1 - idx)
+			.unwrap_or(len)
 	}
 
 	/// Copies the bits from `src` into `self`.

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -317,3 +317,24 @@ fn issue_114() {
 	assert_eq!(one_one.first_one(), Some(0));
 	assert_eq!(one_one.last_one(), Some(0));
 }
+
+/** Test case for [Issue #???], opened by [@hzuo].
+
+The logic for `{leading, trailing}_{zeros, ones}` works by finding the index
+of the opposite bit. If the opposite bit does not exist, the correct behavior
+is to return the whole length of the slice, rather than 0.
+
+[Issue #???]: https://github.com/bitvecto-rs/bitvec/issues/???
+[@VilleHallivuori]: https://github.com/hzuo
+**/
+#[test]
+fn issue_next() {
+	let one_zero = bits![0];
+	let one_one = bits![1];
+
+	assert_eq!(one_zero.leading_zeros(), 1);
+	assert_eq!(one_one.leading_ones(), 1);
+
+	assert_eq!(one_zero.trailing_zeros(), 1);
+	assert_eq!(one_one.trailing_ones(), 1);
+}

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -325,7 +325,7 @@ of the opposite bit. If the opposite bit does not exist, the correct behavior
 is to return the whole length of the slice, rather than 0.
 
 [Issue #120]: https://github.com/bitvecto-rs/bitvec/issues/120
-[@VilleHallivuori]: https://github.com/hzuo
+[@hzuo]: https://github.com/hzuo
 **/
 #[test]
 fn issue_120() {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -318,17 +318,17 @@ fn issue_114() {
 	assert_eq!(one_one.last_one(), Some(0));
 }
 
-/** Test case for [Issue #???], opened by [@hzuo].
+/** Test case for [Issue #120], opened by [@hzuo].
 
 The logic for `{leading, trailing}_{zeros, ones}` works by finding the index
 of the opposite bit. If the opposite bit does not exist, the correct behavior
 is to return the whole length of the slice, rather than 0.
 
-[Issue #???]: https://github.com/bitvecto-rs/bitvec/issues/???
+[Issue #120]: https://github.com/bitvecto-rs/bitvec/issues/120
 [@VilleHallivuori]: https://github.com/hzuo
 **/
 #[test]
-fn issue_next() {
+fn issue_120() {
 	let one_zero = bits![0];
 	let one_one = bits![1];
 


### PR DESCRIPTION
Fixes #120 