### PR TITLE
Decode with String rather than &str

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ serde = "1"
 serde_json = "1"
 serde_test = "1"
 static_assertions = "1"
+tempfile = "3.2"
 
 [[bench]]
 name = "memcpy"

--- a/src/serdes.rs
+++ b/src/serdes.rs
@@ -319,8 +319,8 @@ where
 		let mut bits: Option<u64> = None;
 		let mut data: Option<Vec<T>> = None;
 
-		while let Some(key) = map.next_key()? {
-			match key {
+		while let Some(key) = map.next_key::<String>()? {
+			match key.as_str() {
 				"head" => {
 					if head.replace(map.next_value()?).is_some() {
 						return Err(de::Error::duplicate_field("head"));


### PR DESCRIPTION
When deserializing bitvec as a map, decode the key explicitly as a
String. Otherwise, it will try to decode as &str, which breaks on
serde_json where decoding a string requires ownership for unescaping:

    Failed to parse json: invalid type: string "head", expected a
    borrowed string at line 362 column 15