### PR TITLE
Make 0.20.x version compatible with funty 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes will be documented in this file.
 
 This document is written according to the [Keep a Changelog][kac] style.
 
+1. [0.20.3](#0203)
 1. [0.20.2](#0202)
 1. [0.20.1](#0201)
 1. [0.20.0](#0200)
@@ -58,6 +59,10 @@ This document is written according to the [Keep a Changelog][kac] style.
 1. [0.3.0](#030)
 1. [0.2.0](#020)
 1. [0.1.0](#010)
+
+## 0.20.3
+
+Backports [#114].
 
 ## 0.20.2
 
@@ -1129,6 +1134,7 @@ Initial implementation and release.
 [@Fotosmile]: https://github.com/Fotosmile
 [@GeorgeGkas]: https://github.com/GeorgeGkas
 [@ImmemorConsultrixContrarie]: https://github.com/ImmemorConsultrixContrarie
+[@VilleHallivuori]: https://github.com/VilleHallivuori
 [@arucil]: https://github.com/arucil
 [@caelunshun]: https://github.com/caelunshun
 [@geq1t]: https://github.com/geq1t
@@ -1163,6 +1169,7 @@ Initial implementation and release.
 [Issue #69]: https://github.com/myrrlyn/bitvec/issues/69
 [Issue #75]: https://github.com/myrrlyn/bitvec/issues/75
 [Issue #83]: https://github.com/myrrlyn/bitvec/issues/83
+[Issue #114]: https://github.com/myrrlyn/bitvec/issues/114
 [Pull Request #34]: https://github.com/myrrlyn/bitvec/pull/34
 [Pull Request #41]: https://github.com/myrrlyn/bitvec/pull/41
 [Pull Request #68]: https://github.com/myrrlyn/bitvec/pull/68

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes will be documented in this file.
 
 This document is written according to the [Keep a Changelog][kac] style.
 
+1. [0.20.2](#0202)
+1. [0.20.1](#0201)
 1. [0.20.0](#0200)
    1. [Added](#added)
       1. [Pointer Overhaul](#pointer-overhaul)
@@ -56,6 +58,18 @@ This document is written according to the [Keep a Changelog][kac] style.
 1. [0.3.0](#030)
 1. [0.2.0](#020)
 1. [0.1.0](#010)
+
+## 0.20.2
+
+Fixed overly vague `funty` dependency, as the `1.2` release moved `BITS` from
+`bitvec` into it, but old `bitvec`s now collided. Apologies to *everyone* who
+dealt with this problem after I published and *immediately* went on vacation for
+two weeks!
+
+## 0.20.1
+
+This largely addresses defect reports. In addition, the `IterOnes` and
+`IterZeros` bit-finding iterators are accelerated by specialization.
 
 ## 0.20.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "bitvec"
-version = "0.20.4"
+version = "0.20.5"
 authors = [
 	"myrrlyn <self@myrrlyn.dev>",
 ]
@@ -55,7 +55,7 @@ radium = "0.6.1"
 tap = "1"
 
 [dependencies.funty]
-version = "~1.1"
+version = "1.1"
 default-features = false
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "bitvec"
-version = "0.20.3"
+version = "0.20.4"
 authors = [
 	"myrrlyn <self@myrrlyn.dev>",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "bitvec"
-version = "0.20.0"
+version = "0.20.2"
 authors = [
 	"myrrlyn <self@myrrlyn.dev>",
 ]
@@ -55,7 +55,7 @@ radium = "0.6.1"
 tap = "1"
 
 [dependencies.funty]
-version = "1"
+version = "~1.1"
 default-features = false
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "bitvec"
-version = "0.20.2"
+version = "0.20.3"
 authors = [
 	"myrrlyn <self@myrrlyn.dev>",
 ]

--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -119,7 +119,7 @@ are dominant."
 		println!("{:?}", bs.domain());
 		println!("Show the bits in memory");
 		for elt in bs.domain() {
-			println!("{:0w$b} ", elt, w = T::Mem::BITS as usize);
+			println!("{:0w$b} ", elt, w = <T::Mem as BitMemory>::BITS as usize);
 		}
 		println!();
 	}

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -225,7 +225,7 @@ where
 		let mut boxed = ManuallyDrop::new(boxed);
 
 		BitPtr::from_mut_slice(&mut boxed[..])
-			.span(boxed.len() * T::Mem::BITS as usize)
+			.span(boxed.len() * <T::Mem as BitMemory>::BITS as usize)
 			.map(|bitspan| Self { bitspan })
 			.map_err(|_| ManuallyDrop::into_inner(boxed))
 	}
@@ -438,7 +438,7 @@ where
 		let (_, head, bits) = bp.raw_parts();
 		let head = head.value() as usize;
 		let tail = head + bits;
-		let full = crate::mem::elts::<T::Mem>(tail) * T::Mem::BITS as usize;
+		let full = crate::mem::elts::<T::Mem>(tail) * <T::Mem as BitMemory>::BITS as usize;
 		unsafe {
 			bp.set_head(BitIdx::ZERO);
 			bp.set_len(full);

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -231,7 +231,7 @@ macro_rules! bit_domain {
 				let bitspan = slice.as_bitspan();
 				let h = bitspan.head();
 				let (e, t) = h.span(bitspan.len());
-				let w = T::Mem::BITS;
+				let w = <T::Mem as BitMemory>::BITS;
 
 				match (h.value(), e, t.value()) {
 					(_, 0, _) => Self::empty(),
@@ -258,7 +258,7 @@ macro_rules! bit_domain {
 			) -> Self {
 				let (head, rest) = bit_domain!(split $($m)?
 					slice,
-					(T::Mem::BITS - head.value()) as usize,
+					(<T::Mem as BitMemory>::BITS - head.value()) as usize,
 				);
 				let (body, tail) = bit_domain!(split $($m)?
 					rest,
@@ -289,7 +289,7 @@ macro_rules! bit_domain {
 			) -> Self {
 				let (head, rest) = bit_domain!(split $($m)?
 					slice,
-					(T::Mem::BITS - head.value()) as usize,
+					(<T::Mem as BitMemory>::BITS - head.value()) as usize,
 				);
 				let (head, body) = (
 					bit_domain!(retype $($m)? head),
@@ -537,7 +537,7 @@ macro_rules! domain {
 				let head = bitspan.head();
 				let elts = bitspan.elements();
 				let tail = bitspan.tail();
-				let bits = T::Mem::BITS;
+				let bits = <T::Mem as BitMemory>::BITS;
 				let base = bitspan.address().to_const() as *const _;
 				match (head.value(), elts, tail.value()) {
 					(_, 0, _) => Self::empty(),

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -44,11 +44,11 @@ pub trait BitMemory: IsUnsigned + seal::Sealed {
 	const BITS: u8 = mem::size_of::<Self>() as u8 * 8;
 
 	/// The number of bits required to store an index in the range `0 .. BITS`.
-	const INDX: u8 = Self::BITS.trailing_zeros() as u8;
+	const INDX: u8 = <Self as BitMemory>::BITS.trailing_zeros() as u8;
 
 	/// A mask over all bits that can be used as an index within the element.
 	/// This is the value with the least significant `INDX`-many bits set high.
-	const MASK: u8 = Self::BITS - 1;
+	const MASK: u8 = <Self as BitMemory>::BITS - 1;
 }
 
 /** Description of a processor register.

--- a/src/order.rs
+++ b/src/order.rs
@@ -30,7 +30,7 @@ use crate::{
 		BitSel,
 		BitTail,
 	},
-	mem::BitRegister,
+	mem::{BitRegister, BitMemory},
 };
 
 /** An ordering over a register.
@@ -288,7 +288,7 @@ unsafe impl BitOrder for Lsb0 {
 			upto
 		);
 		let ct = upto - from;
-		if ct == R::BITS {
+		if ct == <R as BitMemory>::BITS {
 			return BitMask::ALL;
 		}
 		//  1. Set all bits in the mask high
@@ -336,7 +336,7 @@ unsafe impl BitOrder for Msb0 {
 			upto
 		);
 		let ct = upto - from;
-		if ct == R::BITS {
+		if ct == <R as BitMemory>::BITS {
 			return BitMask::ALL;
 		}
 		//  1. Set all bits in the mask high.
@@ -447,7 +447,7 @@ where
 	let oname = type_name::<O>();
 	let mname = type_name::<R>();
 
-	for n in 0 .. R::BITS {
+	for n in 0 .. <R as BitMemory>::BITS {
 		//  Wrap the counter as an index.
 		let idx = unsafe { BitIdx::<R>::new_unchecked(n) };
 
@@ -466,14 +466,14 @@ where
 
 		//  If the computed position exceeds the valid range, fail.
 		assert!(
-			pos.value() < R::BITS,
+			pos.value() < <R as BitMemory>::BITS,
 			"Error when verifying the implementation of `BitOrder` for `{}`: \
 			 Index {} produces a bit position ({}) that exceeds the type width \
 			 {}",
 			oname,
 			n,
 			pos.value(),
-			R::BITS,
+			<R as BitMemory>::BITS,
 		);
 
 		//  Check `O`’s implementation of `select`

--- a/src/ptr/span.rs
+++ b/src/ptr/span.rs
@@ -470,8 +470,8 @@ where
 				//  slices of the original type to merge with `head` and `tail`.
 				let (l, c, r) = body.align_to::<U::Mem>();
 
-				let t_bits = T::Mem::BITS as usize;
-				let u_bits = U::Mem::BITS as usize;
+				let t_bits = <T::Mem as BitMemory>::BITS as usize;
+				let u_bits = <U::Mem as BitMemory>::BITS as usize;
 
 				let l_bits = l.len() * t_bits;
 				let c_bits = c.len() * u_bits;
@@ -1009,7 +1009,7 @@ where
 		let (addr_b, head_b, bits_b) = other.raw_parts();
 		//  Since ::BITS is an associated const, the compiler will automatically
 		//  replace the entire function with `false` when the types don’t match.
-		T1::Mem::BITS == T2::Mem::BITS
+		<T1::Mem as BitMemory>::BITS == <T2::Mem as BitMemory>::BITS
 			&& addr_a.value() == addr_b.value()
 			&& head_a.value() == head_b.value()
 			&& bits_a == bits_b

--- a/src/serdes.rs
+++ b/src/serdes.rs
@@ -233,7 +233,7 @@ where
 		let bits = cmp::min(
 			bits,
 			data.len()
-				.saturating_mul(T::Mem::BITS as usize)
+				.saturating_mul(<T::Mem as BitMemory>::BITS as usize)
 				.saturating_sub(head as usize),
 		);
 		//  Assemble a pointer to the start bit,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -488,7 +488,7 @@ where
 	/// [`BitView`]: crate::view::BitView
 	/// [`.view_bits::<O>()`]: crate::view::BitView::view_bits
 	pub fn from_element(elem: &T) -> &Self {
-		unsafe { BitPtr::from_ref(elem).span_unchecked(T::Mem::BITS as usize) }
+		unsafe { BitPtr::from_ref(elem).span_unchecked(<T::Mem as BitMemory>::BITS as usize) }
 			.to_bitslice_ref()
 	}
 
@@ -525,7 +525,7 @@ where
 	/// [`BitView`]: crate::view::BitView
 	/// [`.view_bits_mut::<O>()`]: crate::view::BitView::view_bits_mut
 	pub fn from_element_mut(elem: &mut T) -> &mut Self {
-		unsafe { BitPtr::from_mut(elem).span_unchecked(T::Mem::BITS as usize) }
+		unsafe { BitPtr::from_mut(elem).span_unchecked(<T::Mem as BitMemory>::BITS as usize) }
 			.to_bitslice_mut()
 	}
 
@@ -573,7 +573,7 @@ where
 		//  an inclusive cap. This is also pretty much impossible to hit.
 		if elts >= Self::MAX_ELTS {
 			return Err(BitSpanError::TooLong(
-				elts.saturating_mul(T::Mem::BITS as usize),
+				elts.saturating_mul(<T::Mem as BitMemory>::BITS as usize),
 			));
 		}
 		Ok(unsafe { Self::from_slice_unchecked(slice) })
@@ -641,7 +641,7 @@ where
 		let elts = slice.len();
 		if elts >= Self::MAX_ELTS {
 			return Err(BitSpanError::TooLong(
-				elts.saturating_mul(T::Mem::BITS as usize),
+				elts.saturating_mul(<T::Mem as BitMemory>::BITS as usize),
 			));
 		}
 		Ok(unsafe { Self::from_slice_unchecked_mut(slice) })
@@ -661,7 +661,7 @@ where
 	/// [`MAX_ELTS`]: Self::MAX_ELTS
 	/// [`::from_slice()`]: Self::from_slice
 	pub unsafe fn from_slice_unchecked(slice: &[T]) -> &Self {
-		let bits = slice.len().wrapping_mul(T::Mem::BITS as usize);
+		let bits = slice.len().wrapping_mul(<T::Mem as BitMemory>::BITS as usize);
 		BitPtr::from_slice(slice)
 			.span_unchecked(bits)
 			.to_bitslice_ref()
@@ -681,7 +681,7 @@ where
 	/// [`MAX_ELTS`]: Self::MAX_ELTS
 	/// [`::from_slice_mut()`]: Self::from_slice_mut
 	pub unsafe fn from_slice_unchecked_mut(slice: &mut [T]) -> &mut Self {
-		let bits = slice.len().wrapping_mul(T::Mem::BITS as usize);
+		let bits = slice.len().wrapping_mul(<T::Mem as BitMemory>::BITS as usize);
 		BitPtr::from_mut_slice(slice)
 			.span_unchecked(bits)
 			.to_bitslice_mut()

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1239,6 +1239,86 @@ where
 		self.iter_zeros().next_back()
 	}
 
+	/// Counts the number of bits from the start of the bit-slice to the first
+	/// bit set to `0`.
+	///
+	/// This returns `0` if the bit-slice is empty.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert_eq!(bits![].leading_ones(), 0);
+	/// assert_eq!(bits![0].leading_ones(), 0);
+	/// assert_eq!(bits![1, 0, 1, 1].leading_ones(), 1);
+	/// assert_eq!(bits![1, 1, 1, 1].leading_ones(), 4);
+	/// ```
+	#[inline]
+	pub fn leading_ones(&self) -> usize {
+		self.first_zero().unwrap_or(self.len())
+	}
+
+	/// Counts the number of bits from the start of the bit-slice to the first
+	/// bit set to `1`.
+	///
+	/// This returns `0` if the bit-slice is empty.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert_eq!(bits![].leading_zeros(), 0);
+	/// assert_eq!(bits![1].leading_zeros(), 0);
+	/// assert_eq!(bits![0, 1, 0, 0].leading_zeros(), 1);
+	/// assert_eq!(bits![0, 0, 0, 0].leading_zeros(), 4);
+	/// ```
+	#[inline]
+	pub fn leading_zeros(&self) -> usize {
+		self.first_one().unwrap_or(self.len())
+	}
+
+	/// Counts the number of bits from the end of the bit-slice to the last bit
+	/// set to `0`.
+	///
+	/// This returns `0` if the bit-slice is empty.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert_eq!(bits![].trailing_ones(), 0);
+	/// assert_eq!(bits![0].trailing_ones(), 0);
+	/// assert_eq!(bits![1, 0, 1, 1].trailing_ones(), 2);
+	/// ```
+	#[inline]
+	pub fn trailing_ones(&self) -> usize {
+		let len = self.len();
+		self.last_zero().map(|idx| len - 1 - idx).unwrap_or(len)
+	}
+
+	/// Counts the number of bits from the end of the bit-slice to the last bit
+	/// set to `1`.
+	///
+	/// This returns `0` if the bit-slice is empty.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert_eq!(bits![].trailing_zeros(), 0);
+	/// assert_eq!(bits![1].trailing_zeros(), 0);
+	/// assert_eq!(bits![0, 1, 0, 0].trailing_zeros(), 2);
+	/// ```
+	#[inline]
+	pub fn trailing_zeros(&self) -> usize {
+		let len = self.len();
+		self.last_one().map(|idx| len - 1 - idx).unwrap_or(len)
+	}
+
 	/// Copies the bits from `src` into `self`.
 	///
 	/// The length of `src` must be the same as `self.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1179,6 +1179,66 @@ where
 		IterZeros::new(self)
 	}
 
+	/// Gets the index of the first bit in the bit-slice set to `1`.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert!(bits![].first_one().is_none());
+	/// assert_eq!(bits![0, 0, 1].first_one().unwrap(), 2);
+	/// ```
+	#[inline]
+	pub fn first_one(&self) -> Option<usize> {
+		self.iter_ones().next()
+	}
+
+	/// Gets the index of the first bit in the bit-slice set to `0`.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert!(bits![].first_zero().is_none());
+	/// assert_eq!(bits![1, 1, 0].first_zero().unwrap(), 2);
+	/// ```
+	#[inline]
+	pub fn first_zero(&self) -> Option<usize> {
+		self.iter_zeros().next()
+	}
+
+	/// Gets the index of the last bit in the bit-slice set to `1`.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert!(bits![].last_one().is_none());
+	/// assert_eq!(bits![1, 0, 0, 1].last_one().unwrap(), 3);
+	/// ```
+	#[inline]
+	pub fn last_one(&self) -> Option<usize> {
+		self.iter_ones().next_back()
+	}
+
+	/// Gets the index of the last bit in the bit-slice set to `0`.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use bitvec::prelude::*;
+	///
+	/// assert!(bits![].last_zero().is_none());
+	/// assert_eq!(bits![0, 1, 1, 0].last_zero().unwrap(), 3);
+	/// ```
+	#[inline]
+	pub fn last_zero(&self) -> Option<usize> {
+		self.iter_zeros().next_back()
+	}
+
 	/// Copies the bits from `src` into `self`.
 	///
 	/// The length of `src` must be the same as `self.

--- a/src/slice/specialization.rs
+++ b/src/slice/specialization.rs
@@ -170,9 +170,9 @@ where T: BitStore
 	pub(crate) fn sp_iter_ones_last(&self) -> Option<usize> {
 		let mut out = match self.len() {
 			0 => return None,
-			n => n - 1,
+			n => n,
 		};
-		match self.domain() {
+		(|| match self.domain() {
 			Domain::Enclave { head, elem, tail } => {
 				let val = (Lsb0::mask(head, tail) & elem.load_value()).value();
 				let dead_bits = T::Mem::BITS - tail.value();
@@ -213,7 +213,8 @@ where T: BitStore
 
 				None
 			},
-		}
+		})()
+		.map(|idx| idx - 1)
 	}
 
 	/// Seeks the index of the first `0` bit in the bit-slice.
@@ -267,9 +268,9 @@ where T: BitStore
 	pub(crate) fn sp_iter_zeros_last(&self) -> Option<usize> {
 		let mut out = match self.len() {
 			0 => return None,
-			n => n - 1,
+			n => n,
 		};
-		match self.domain() {
+		(|| match self.domain() {
 			Domain::Enclave { head, elem, tail } => {
 				let val = (Lsb0::mask(head, tail) & !elem.load_value()).value();
 				let dead_bits = T::Mem::BITS - tail.value();
@@ -310,7 +311,8 @@ where T: BitStore
 
 				None
 			},
-		}
+		})()
+		.map(|idx| idx - 1)
 	}
 }
 

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -420,7 +420,7 @@ fn unspecialized() {
 			BitIdx,
 			BitPos,
 		},
-		mem::BitRegister,
+		mem::{BitRegister, BitMemory},
 		prelude::*,
 	};
 
@@ -429,7 +429,7 @@ fn unspecialized() {
 	unsafe impl BitOrder for Swizzle {
 		fn at<R>(index: BitIdx<R>) -> BitPos<R>
 		where R: BitRegister {
-			match R::BITS {
+			match <R as BitMemory>::BITS {
 				8 => BitPos::new(index.value() ^ 0b100).unwrap(),
 				16 => BitPos::new(index.value() ^ 0b1100).unwrap(),
 				32 => BitPos::new(index.value() ^ 0b11100).unwrap(),

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -426,7 +426,7 @@ where
 		let capacity = vec.capacity();
 
 		BitPtr::from_mut_slice(vec.as_mut_slice())
-			.span(vec.len() * T::Mem::BITS as usize)
+			.span(vec.len() * <T::Mem as BitMemory>::BITS as usize)
 			.map(|bitspan| Self { bitspan, capacity })
 			.map_err(|_| ManuallyDrop::into_inner(vec))
 	}

--- a/src/vec/api.rs
+++ b/src/vec/api.rs
@@ -283,7 +283,7 @@ where
 	#[inline]
 	pub fn capacity(&self) -> usize {
 		self.capacity
-			.checked_mul(T::Mem::BITS as usize)
+			.checked_mul(<T::Mem as BitMemory>::BITS as usize)
 			.expect("Bit-Vector capacity exceeded")
 			//  Don’t forget to subtract any dead bits in the front of the base!
 			//  This has to be saturating, becase a non-zero head on a zero

--- a/src/view.rs
+++ b/src/view.rs
@@ -203,7 +203,7 @@ macro_rules! view_bits {
 			where O: BitOrder {
 				unsafe { from_raw_parts_unchecked(
 					BitPtr::from_slice(&self[..]),
-					$n * T::Mem::BITS as usize,
+					$n * <T::Mem as BitMemory>::BITS as usize,
 				) }
 			}
 
@@ -212,7 +212,7 @@ macro_rules! view_bits {
 			where O: BitOrder {
 				unsafe { from_raw_parts_unchecked_mut(
 					BitPtr::from_mut_slice(&mut self[..]),
-					$n * T::Mem::BITS as usize,
+					$n * <T::Mem as BitMemory>::BITS as usize,
 				) }
 			}
 

--- a/tests/foreign_order.rs
+++ b/tests/foreign_order.rs
@@ -12,7 +12,7 @@ use bitvec::{
 		BitIdx,
 		BitPos,
 	},
-	mem::BitRegister,
+	mem::{BitRegister, BitMemory},
 	prelude::*,
 };
 
@@ -21,7 +21,7 @@ pub struct Swizzle;
 unsafe impl BitOrder for Swizzle {
 	fn at<R>(index: BitIdx<R>) -> BitPos<R>
 	where R: BitRegister {
-		match R::BITS {
+		match <R as BitMemory>::BITS {
 			8 => BitPos::new(index.value() ^ 0b100).unwrap(),
 			16 => BitPos::new(index.value() ^ 0b1100).unwrap(),
 			32 => BitPos::new(index.value() ^ 0b11100).unwrap(),

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -317,3 +317,24 @@ fn issue_114() {
 	assert_eq!(one_one.first_one(), Some(0));
 	assert_eq!(one_one.last_one(), Some(0));
 }
+
+/** Test case for [Issue #???], opened by [@hzuo].
+
+The logic for `{leading, trailing}_{zeros, ones}` works by finding the index
+of the opposite bit. If the opposite bit does not exist, the correct behavior
+is to return the whole length of the slice, rather than 0.
+
+[Issue #???]: https://github.com/bitvecto-rs/bitvec/issues/???
+[@VilleHallivuori]: https://github.com/hzuo
+**/
+#[test]
+fn issue_next() {
+	let one_zero = bits![0];
+	let one_one = bits![1];
+
+	assert_eq!(one_zero.leading_zeros(), 1);
+	assert_eq!(one_one.leading_ones(), 1);
+
+	assert_eq!(one_zero.trailing_zeros(), 1);
+	assert_eq!(one_one.trailing_ones(), 1);
+}

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,6 +1,7 @@
 //! Test cases for defect reports.
 
-#[cfg(feature = "alloc")]
+#![allow(clippy::unusual_byte_groupings)]
+
 use bitvec::prelude::*;
 
 /** Test case for [Issue #10], opened by [@overminder].
@@ -270,4 +271,49 @@ fn issue_77() {
 	// Also notice, `bv` only contains `true`, but with `N` < 4, the `last_few`
 	// are all `false`!!!
 	assert_eq!(&[&true; N], last_few.as_slice());
+}
+
+/** Test case for [Issue #114], opened by [@VilleHallivuori].
+
+This report describes an overflowing-subtraction error encountered when
+attempting to find the last index of an un/set bit in a bit-slice that does not
+have any.
+
+This is not a surprising crash: the reverse gallop by indices through a slice is
+a cumbersome operation that is fraught with potential for failure, thanks to the
+half-open nature of indices within a length.
+
+The fix turned out to be incredibly simple: defer the derement operation (to go
+from len to last valid index) from the *start* of the search to the *end*.
+
+I am not confident in the categorical correctness of this solution, but it fixes
+the provided test cases and does not break the existing tests.
+
+I will need to devise test cases that thoroughly check all possible branches of
+the galloping searches, but for now, this is an improvement over the existing
+behavior, so I am going to call it sufficient for the bug as reported, publish
+patches, and await further reports.
+
+[Issue #114]: https://github.com/bitvecto-rs/bitvec/issues/114
+[@VilleHallivuori]: https://github.com/VilleHallivuori
+**/
+#[test]
+fn issue_114() {
+	let one_zero = bits![0];
+	let one_one = bits![1];
+
+	assert_eq!(one_zero.count_zeros(), 1);
+	assert_eq!(one_zero.count_ones(), 0);
+	assert_eq!(one_one.count_zeros(), 0);
+	assert_eq!(one_one.count_ones(), 1);
+
+	assert!(one_zero.first_one().is_none());
+	assert!(one_zero.last_one().is_none());
+	assert!(one_one.first_zero().is_none());
+	assert!(one_one.last_zero().is_none());
+
+	assert_eq!(one_zero.first_zero(), Some(0));
+	assert_eq!(one_zero.last_zero(), Some(0));
+	assert_eq!(one_one.first_one(), Some(0));
+	assert_eq!(one_one.last_one(), Some(0));
 }


### PR DESCRIPTION
Hi!
Recently I tried to introduce a new dependency into a project I'm working on and encountered this issue: https://github.com/bitvecto-rs/bitvec/issues/105
Unfortunately I didn't find a way to solve this dependency compilation failure in my project, as we already have another dependency that requires bitvec 0.22.x which requires funty 1.2.  The new dependency I want to introduce requires bitvec 0.20.x which isn't compatible with funty 1.2; and it seems it's not possible to have funty 1.1 and funty 1.2 at the same time.

This PR is an update from https://github.com/bitvecto-rs/bitvec/pull/110 but for the latest release in the 0.20.x version.  It makes bitvec 0.20.x work with funty 1.1 and funty 1.2.  I've also updated the version in `Cargo.toml` to 0.20.5 and would like to ask if you could publish this release to crates.io.

I didn't find any branch for the 0.20.x version, so I made the PR agains develop, but it obviously is not compatible.  Is there a better way for me to submit a PR for the 0.20.x branch?