### PR TITLE
Use qualified path for core::cell::Cell when feature atomic is disabled

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -269,7 +269,7 @@ macro_rules! safe {
 
 			#[cfg(not(feature = "atomic"))]
 			const ZERO: Self = Self {
-				inner: Cell::new(0),
+				inner: core::cell::Cell::new(0),
 			};
 
 			fn load(&self) -> $t {


### PR DESCRIPTION
bitvec's develop branch does not currently compile with `default-features = false` because one definition of the `ZERO` constant is missing a qualified module path for `Cell`.