### PR TITLE
Remove unused import of MaybeUninit

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -17,7 +17,6 @@ value position, and delegates to `BitSlice` for all actual work.
 
 use core::{
 	marker::PhantomData,
-	mem::MaybeUninit,
 	slice,
 };
 


### PR DESCRIPTION
`MaybeUninit` is used with a fully qualified path:

```
            data: unsafe { core::mem::MaybeUninit::zeroed().assume_init() },
```

The import is unused and is generating warning.