### PR TITLE
Fix miri failures by preserving provenance in `BitSpan::new_unchecked`

### DIFF
--- a/src/devel.rs
+++ b/src/devel.rs
@@ -103,3 +103,9 @@ where
 {
 	TypeId::of::<T>() == TypeId::of::<U>()
 }
+
+/// Converts `addr` to a pointer using the provenance of `prov`.
+pub fn int_to_ptr_with_provenance<T>(addr: usize, prov: *const T) -> *const T {
+	let ptr = prov.cast::<u8>();
+	ptr.wrapping_add(addr.wrapping_sub(ptr as usize)).cast()
+}


### PR DESCRIPTION
It seems the fix for the miri failures proposed by @tavianator hasn't been committed yet so I gave it a go.

Fix the miri failures in doctests, see issue #135. The issue is that miri doesn't guess correct provenance in the int-to-ptr cast in `BitSpan::new_unchecked`, as was found by @tavianator [here](https://github.com/rust-lang/miri/issues/1866#issuecomment-985770125).

The solution is to preserve provenance and was proposed by  @tavianator [here](https://github.com/rust-lang/miri/issues/1866#issuecomment-986068198). With this change the entire test suite passes under miri.