### PR TITLE
Remove unprocessed HTML from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div class="title-block" style="text-align: center;" align="center">
+<div style="text-align: center;" align="center">
 
 # `bitvec`
 
@@ -424,9 +424,3 @@ does, how it works, and how it can be useful to you.
 [`radium`]: https://crates.io/crates/radium
 [`std::bitset<N>`]: https://en.cppreference.com/w/cpp/utility/bitset
 [`std::vector<bool>`]: https://en.cppreference.com/w/cpp/container/vector_bool
-
-<style type="text/css">
-.title-block {
-  text-align: center;
-}
-</style>


### PR DESCRIPTION
Congrats on the 1.0 release!

I was reading through the README on crates.io and noticed the `<style>` tag at the bottom was getting rendered as text; it looks like the relevant CSS is inline in the title div anyway so perhaps it could just be removed?

On the other hand I see it was only added recently in aab0907fe59fe2421e10e9931cf09ce115cadb5c so maybe it needs to be there for something, sorry for the noise if so!