### PR TITLE
Handle bitvec![x; len] for a runtime len

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -342,6 +342,9 @@ macro_rules! bitvec {
 	($store:ty, $order:ty; $val:expr; $len:expr) => {
 		$crate::vec::BitVec::<$store, $order>::repeat($val != 0, $len)
 	};
+	($val:expr; $len:expr) => {
+		$crate::bitvec!(usize, $crate::order::Lsb0; $val; $len)
+	};
 
 	//  Delegate all others to the `bits!` macro.
 	($($arg:tt)*) => {


### PR DESCRIPTION
Far as I can tell this should be backwards compatible? Unless there's something weird with promotion when moving an expression from a constant to a runtime evaluation.
