### PR TITLE
Support more serialization/deserialization targets: Deserialize into owned strings if "alloc" feature is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes will be documented in this file.
 This document is written according to the [Keep a Changelog][kac] style.
 
 1. [Version 1](#version-1)
-   1. [1.0](#10)
+   1. [1.1.0](#110)
+   1. [1.0.1](#101)
+   1. [1.0](#100)
 1. [Version 0 (Prototyping)](#version-0-prototyping)
    1. [0.22](#022)
    1. [0.21](#021)
@@ -35,6 +37,15 @@ This document is written according to the [Keep a Changelog][kac] style.
 `bitvec`’s initial development is now complete, and uses the one-dot series. It
 will continue to receive maintenance, but its API is now stable and **will not**
 change until const-generics allow `BitArray` to be rewritten.
+
+### 1.1.0
+
+Deserialize into owned strings if the `alloc` and `serde` features are enabled,
+to support deserializing via libraries like `serde_json` which expect owned 
+strings. See [Pull Request #175] for more detail.
+
+This requires bumping the MSRV to `1.60`, which is the version that optional 
+dependencies were added in.
 
 ### 1.0.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 
 categories = [
@@ -36,7 +36,7 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/bitvecto-rs/bitvec"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [features]
 alloc = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ rust-version = "1.56"
 
 [features]
 alloc = [
+	# If the serde feature is also enabled, enable alloc for it
+	# so that we can deserialize Strings.
+	"serde?/alloc"
 ]
 atomic = [
 ]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ However, it does also have some small costs associated with its capabilities:
 
 ## Usage
 
-**Minimum Supported Rust Version**: 1.56.0
+**Minimum Supported Rust Version**: 1.60.0
 
 `bitvec` strives to follow the sequence APIs in the standard library. However,
 as most of its functionality is a reïmplementation that does not require the

--- a/doc/serdes/utils.md
+++ b/doc/serdes/utils.md
@@ -13,7 +13,7 @@ from a matching data buffer.
 
 Serde only provides implementations for `[T; 0 ..= 32]`, because it must support
 much older Rust versions (at time of writing, 1.15+) that do not have
-const-generics. As `bitvec` has an MSRV of 1.56; it *does* have const-generics.
+const-generics. As `bitvec` has an MSRV of 1.60; it *does* have const-generics.
 This type reïmplements Serde’s array behavior for all arrays, so that `bitvec`
 can transport any `BitArray` rather than only small bit-arrays.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,7 +6,7 @@
 ########################################################################
 
 [toolchain]
-channel = "1.56.0"
+channel = "1.60.0"
 profile = "default"
 components = [
 	"clippy",

--- a/src/serdes/slice.rs
+++ b/src/serdes/slice.rs
@@ -18,6 +18,7 @@ use serde::{
 		Error,
 		MapAccess,
 		SeqAccess,
+		Unexpected,
 		Visitor,
 	},
 	ser::{
@@ -210,7 +211,7 @@ where
 
 		let expected_order = any::type_name::<O>();
 		if order != expected_order {
-			return Err(E::custom(format!("Wrong order; expecting {} but got {}", order, expected_order)));
+			return Err(E::invalid_type(Unexpected::Str(&*order), &self));
 		}
 		(self.func)(data, head, bits as usize).map_err(|_| todo!())
 	}

--- a/src/serdes/utils.rs
+++ b/src/serdes/utils.rs
@@ -246,8 +246,8 @@ where R: BitRegister
 		let mut width = None;
 		let mut index = None;
 
-		while let Some(key) = map.next_key::<&'de str>()? {
-			match key {
+		while let Some(key) = map.next_key::<StringTarget<'de>>()? {
+			match &*key {
 				"width" => {
 					if width.replace(map.next_value::<u8>()?).is_some() {
 						return Err(<V::Error>::duplicate_field("width"));
@@ -271,6 +271,18 @@ where R: BitRegister
 		self.assemble(width, index)
 	}
 }
+
+/// This is a target used to deserialize strings into.
+/// With the alloc feature enabled, we will deserialize into owned strings,
+/// granting a little more deserialization flexibility.
+#[cfg(feature = "alloc")]
+pub type StringTarget<'de> = String;
+
+/// This is a target used to deserialize strings into.
+/// Without the alloc feature enabled, we will deserialize into borrowed strings,
+/// which makes deserializing from some targets (like JSON) impossible.
+#[cfg(not(feature = "alloc"))]
+pub type StringTarget<'de> = &'de str;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Currently bitvec will attempt to deserialize several things into borrowed strings, which will fail if the `Deserializer` calls `visit_string()` instead of `visit_borrowed_string()` for these things. This is the case with things like `serde_json` and `serde_value`, and probably any deserializers that themselves hold owned strings.

This PR tweaks the behaviour so that when the `alloc` feature is enabled, we deserialize into owned strings instead, allowing bitvec to be deserialized from popular formats like `serde_json`. When the alloc feature isn't enabled, we keep the existing behaviour roughly as-is.

What do you reckon @myrrlyn? :)

Closes #167 