### PR TITLE
Clarify panic message for too-big shift operations on BitSlices

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1418,7 +1418,7 @@ where
 		let len = self.len();
 		assert!(
 			by < len,
-			"cannot shift a bit-slice by more than its length: {} > {}",
+			"shift must be less than the length of the bit-slice: {} >= {}",
 			by,
 			len,
 		);
@@ -1459,7 +1459,7 @@ where
 		let len = self.len();
 		assert!(
 			by < len,
-			"cannot shift a bit-slice by more than its length: {} > {}",
+			"shift must be less than the length of the bit-slice: {} >= {}",
 			by,
 			len,
 		);


### PR DESCRIPTION
Thanks for creating this library.  I was using this crate in a project of mine, and I got a confusing error message when I tried to shift a BitSlice by an amount equal to its length: `cannot shift a bit-slice by more than its length: 100 > 100`.  This PR just rewords the error message to read: `shift must be less than the length of the bit-slice: 100 >= 100`.

I also double-checked the docs, and they correctly describe the requirement for the shift operation.

Hope this helps!