### PR TITLE
Format with rustfmt following `option_env!` commit

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -52,8 +52,15 @@ pub trait BitField {
 		}
 		else {
 			match option_env!("CARGO_PKG_REPOSITORY") {
-				Some(env) => unreachable!("This architecture is not supported! Please consider filing an issue at {}", env),
-				None => unreachable!("This architecture is not supported! Please consider filing an issue"),
+				Some(env) => unreachable!(
+					"This architecture is not supported! Please consider \
+					 filing an issue at {}",
+					env,
+				),
+				None => unreachable!(
+					"This architecture is not supported! Please consider \
+					 filing an issue",
+				),
 			}
 		}
 	}
@@ -70,8 +77,15 @@ pub trait BitField {
 		}
 		else {
 			match option_env!("CARGO_PKG_REPOSITORY") {
-				Some(env) => unreachable!("This architecture is not supported! Please consider filing an issue at {}", env),
-				None => unreachable!("This architecture is not supported! Please consider filing an issue"),
+				Some(env) => unreachable!(
+					"This architecture is not supported! Please consider \
+					 filing an issue at {}",
+					env,
+				),
+				None => unreachable!(
+					"This architecture is not supported! Please consider \
+					 filing an issue",
+				),
 			}
 		}
 	}

--- a/src/order.rs
+++ b/src/order.rs
@@ -221,7 +221,9 @@ pub use self::Lsb0 as LocalBits;
 pub use self::Msb0 as LocalBits;
 
 #[cfg(not(any(target_endian = "big", target_endian = "little")))]
-compile_fail!("This architecture is not supported! Please consider filing an issue");
+compile_fail!(
+	"This architecture is not supported! Please consider filing an issue",
+);
 
 #[inline]
 #[cfg(not(tarpaulin_include))]


### PR DESCRIPTION
The CONTRIBUTING.md requests that contributions be auto-formatted by rustfmt, however I found that rustfmt was making changes unrelated to my own change. It looks like this is because the recent commit 8dcc6e96f012daade242318645d97487e59fbe6d was not properly formatted.