### PR TITLE
Borrow field identifiers from deserializer, instead of input

### DIFF
--- a/src/serdes/array.rs
+++ b/src/serdes/array.rs
@@ -6,7 +6,6 @@ use core::{
 		self,
 		Formatter,
 	},
-	marker::PhantomData,
 };
 
 use serde::{
@@ -28,6 +27,8 @@ use serde::{
 
 use super::{
 	utils::Array,
+	Field,
+	TypeName,
 	FIELDS,
 };
 use crate::{
@@ -88,11 +89,7 @@ where
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where D: Deserializer<'de> {
 		deserializer
-			.deserialize_struct(
-				"BitArr",
-				FIELDS,
-				BitArrVisitor::<'de, T, O, 1>::THIS,
-			)
+			.deserialize_struct("BitArr", FIELDS, BitArrVisitor::<T, O, 1>::THIS)
 			.map(|BitArray { data: [elem], .. }| BitArray::new(elem))
 	}
 }
@@ -108,22 +105,19 @@ where
 		deserializer.deserialize_struct(
 			"BitArr",
 			FIELDS,
-			BitArrVisitor::<'de, T, O, N>::THIS,
+			BitArrVisitor::<T, O, N>::THIS,
 		)
 	}
 }
 
 /// Assists in deserialization of a static `BitArr`.
-struct BitArrVisitor<'de, T, O, const N: usize>
+struct BitArrVisitor<T, O, const N: usize>
 where
 	T: BitStore,
 	O: BitOrder,
-	Array<T, N>: Deserialize<'de>,
 {
-	/// This produces a bit-array value during its work.
-	typ:   PhantomData<BitArray<T, O>>,
 	/// The deserialized bit-ordering string.
-	order: Option<&'de str>,
+	order: Option<TypeName<O>>,
 	/// The deserialized head-bit index. This must be zero; it is used for
 	/// consistency with `BitSeq` and to carry `T::Mem` information.
 	head:  Option<BitIdx<T::Mem>>,
@@ -133,7 +127,7 @@ where
 	data:  Option<Array<T, N>>,
 }
 
-impl<'de, T, O, const N: usize> BitArrVisitor<'de, T, O, N>
+impl<'de, T, O, const N: usize> BitArrVisitor<T, O, N>
 where
 	T: BitStore,
 	O: BitOrder,
@@ -141,7 +135,6 @@ where
 {
 	/// A new visitor in its ready condition.
 	const THIS: Self = Self {
-		typ:   PhantomData,
 		order: None,
 		head:  None,
 		bits:  None,
@@ -151,15 +144,11 @@ where
 	/// Attempts to assemble deserialized components into an output value.
 	fn assemble<E>(mut self) -> Result<BitArray<[T; N], O>, E>
 	where E: Error {
-		let order =
-			self.order.take().ok_or_else(|| E::missing_field("order"))?;
+		self.order.take().ok_or_else(|| E::missing_field("order"))?;
 		let head = self.head.take().ok_or_else(|| E::missing_field("head"))?;
 		let bits = self.bits.take().ok_or_else(|| E::missing_field("bits"))?;
 		let data = self.data.take().ok_or_else(|| E::missing_field("data"))?;
 
-		if order != any::type_name::<O>() {
-			return Err(E::invalid_type(Unexpected::Str(order), &self));
-		}
 		if head != BitIdx::MIN {
 			return Err(E::invalid_value(
 				Unexpected::Unsigned(head.into_inner() as u64),
@@ -175,7 +164,7 @@ where
 	}
 }
 
-impl<'de, T, O, const N: usize> Visitor<'de> for BitArrVisitor<'de, T, O, N>
+impl<'de, T, O, const N: usize> Visitor<'de> for BitArrVisitor<T, O, N>
 where
 	T: BitStore,
 	O: BitOrder,
@@ -217,31 +206,27 @@ where
 
 	fn visit_map<V>(mut self, mut map: V) -> Result<Self::Value, V::Error>
 	where V: MapAccess<'de> {
-		while let Some(key) = map.next_key::<&'de str>()? {
+		while let Some(key) = map.next_key()? {
 			match key {
-				"order" => {
+				Field::Order => {
 					if self.order.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("order"));
 					}
 				},
-				"head" => {
+				Field::Head => {
 					if self.head.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("head"));
 					}
 				},
-				"bits" => {
+				Field::Bits => {
 					if self.bits.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("bits"));
 					}
 				},
-				"data" => {
+				Field::Data => {
 					if self.data.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("data"));
 					}
-				},
-				f => {
-					let _ = map.next_value::<()>();
-					return Err(<V::Error>::unknown_field(f, FIELDS));
 				},
 			}
 		}
@@ -279,6 +264,10 @@ mod tests {
 		let array3 = serde_json::from_str::<BA>(&json)?;
 		assert_eq!(array, array3);
 
+		let json_value = serde_json::to_value(&array)?;
+		let array4 = serde_json::from_value::<BA>(json_value)?;
+		assert_eq!(array, array4);
+
 		type BA2 = BitArray<u16, Msb0>;
 		let array = BA2::new(44203);
 
@@ -289,6 +278,10 @@ mod tests {
 		let json = serde_json::to_string(&array)?;
 		let array3 = serde_json::from_str::<BA2>(&json)?;
 		assert_eq!(array, array3);
+
+		let json_value = serde_json::to_value(&array)?;
+		let array4 = serde_json::from_value::<BA2>(json_value)?;
+		assert_eq!(array, array4);
 
 		Ok(())
 	}
@@ -341,9 +334,21 @@ mod tests {
 	#[cfg(feature = "alloc")]
 	fn errors() {
 		type BA = BitArr!(for 8, in u8, Msb0);
-		let tokens = &mut [
+		let mut tokens = vec![
 			Token::Seq { len: Some(4) },
 			Token::BorrowedStr(any::type_name::<Msb0>()),
+		];
+
+		assert_de_tokens_error::<BitArr!(for 8, in u8, Lsb0)>(
+			&tokens,
+			&format!(
+				"invalid value: string \"{}\", expected the string \"{}\"",
+				any::type_name::<Msb0>(),
+				any::type_name::<Lsb0>(),
+			),
+		);
+
+		tokens.extend([
 			Token::Seq { len: Some(2) },
 			Token::U8(8),
 			Token::U8(0),
@@ -353,24 +358,18 @@ mod tests {
 			Token::U8(0),
 			Token::TupleEnd,
 			Token::SeqEnd,
-		];
-
-		assert_de_tokens_error::<BitArr!(for 8, in u8, Lsb0)>(
-			tokens,
-			"invalid type: string \"bitvec::order::Msb0\", expected a \
-			 `BitArray<[u8; 1], bitvec::order::Lsb0>`",
-		);
+		]);
 
 		tokens[6] = Token::U64(7);
 		assert_de_tokens_error::<BA>(
-			tokens,
+			&tokens,
 			"invalid length 7, expected a `BitArray<[u8; 1], \
 			 bitvec::order::Msb0>`",
 		);
 
 		tokens[4] = Token::U8(1);
 		assert_de_tokens_error::<BA>(
-			tokens,
+			&tokens,
 			"invalid value: integer `1`, expected `BitArray` must have a \
 			 head-bit of `0`",
 		);
@@ -382,8 +381,6 @@ mod tests {
 					len:  2,
 				},
 				Token::BorrowedStr("placeholder"),
-				Token::Unit,
-				Token::StructEnd,
 			],
 			&format!(
 				"unknown field `placeholder`, expected one of `{}`",

--- a/src/serdes/slice.rs
+++ b/src/serdes/slice.rs
@@ -18,7 +18,6 @@ use serde::{
 		Error,
 		MapAccess,
 		SeqAccess,
-		Unexpected,
 		Visitor,
 	},
 	ser::{
@@ -29,7 +28,11 @@ use serde::{
 };
 use wyz::comu::Const;
 
-use super::FIELDS;
+use super::{
+	Field,
+	TypeName,
+	FIELDS,
+};
 #[cfg(feature = "alloc")]
 use crate::{
 	boxed::BitBox,
@@ -102,7 +105,7 @@ where O: BitOrder
 		deserializer.deserialize_struct(
 			"BitSeq",
 			FIELDS,
-			BitSeqVisitor::<'de, u8, O, &'de [u8], Self, _>::new(
+			BitSeqVisitor::<u8, O, &'de [u8], Self, _>::new(
 				|data, head, bits| unsafe {
 					BitSpan::new(data.as_ptr().into_address(), head, bits)
 						.map(|span| BitSpan::into_bitslice_ref(span))
@@ -138,7 +141,7 @@ where
 		deserializer.deserialize_struct(
 			"BitSeq",
 			FIELDS,
-			BitSeqVisitor::<'de, T, O, Vec<T>, Self, _>::new(
+			BitSeqVisitor::<T, O, Vec<T>, Self, _>::new(
 				|vec, head, bits| unsafe {
 					let addr = vec.as_ptr().into_address();
 					let mut bv = BitVec::try_from_vec(vec).map_err(|_| {
@@ -155,19 +158,16 @@ where
 }
 
 /// Assists in deserialization of a dynamic `BitSeq`.
-struct BitSeqVisitor<'de, T, O, In, Out, Func>
+struct BitSeqVisitor<T, O, In, Out, Func>
 where
-	T: 'de + BitStore,
+	T: BitStore,
 	O: BitOrder,
-	In: Deserialize<'de>,
 	Func: FnOnce(In, BitIdx<T::Mem>, usize) -> Result<Out, BitSpanError<T>>,
 {
-	/// This produces a bit-slice reference during its work,
-	typ:   PhantomData<&'de BitSlice<T, O>>,
 	/// As well as a final output value.
 	out:   PhantomData<Result<Out, BitSpanError<T>>>,
 	/// The deserialized bit-ordering string.
-	order: Option<&'de str>,
+	order: Option<TypeName<O>>,
 	/// The deserialized head-bit index.
 	head:  Option<BitIdx<T::Mem>>,
 	/// The deserialized bit-count.
@@ -179,7 +179,7 @@ where
 	func:  Func,
 }
 
-impl<'de, T, O, In, Out, Func> BitSeqVisitor<'de, T, O, In, Out, Func>
+impl<'de, T, O, In, Out, Func> BitSeqVisitor<T, O, In, Out, Func>
 where
 	T: 'de + BitStore,
 	O: BitOrder,
@@ -189,7 +189,6 @@ where
 	/// Creates a new visitor with a given transform functor.
 	fn new(func: Func) -> Self {
 		Self {
-			typ: PhantomData,
 			out: PhantomData,
 			order: None,
 			head: None,
@@ -202,21 +201,17 @@ where
 	/// Attempts to assemble deserialized components into an output value.
 	fn assemble<E>(mut self) -> Result<Out, E>
 	where E: Error {
-		let order =
-			self.order.take().ok_or_else(|| E::missing_field("order"))?;
+		self.order.take().ok_or_else(|| E::missing_field("order"))?;
 		let head = self.head.take().ok_or_else(|| E::missing_field("head"))?;
 		let bits = self.bits.take().ok_or_else(|| E::missing_field("bits"))?;
 		let data = self.data.take().ok_or_else(|| E::missing_field("data"))?;
 
-		if order != any::type_name::<O>() {
-			return Err(E::invalid_type(Unexpected::Str(order), &self));
-		}
 		(self.func)(data, head, bits as usize).map_err(|_| todo!())
 	}
 }
 
 impl<'de, T, O, In, Out, Func> Visitor<'de>
-	for BitSeqVisitor<'de, T, O, In, Out, Func>
+	for BitSeqVisitor<T, O, In, Out, Func>
 where
 	T: 'de + BitStore,
 	O: BitOrder,
@@ -258,31 +253,27 @@ where
 
 	fn visit_map<V>(mut self, mut map: V) -> Result<Self::Value, V::Error>
 	where V: MapAccess<'de> {
-		while let Some(key) = map.next_key::<&'de str>()? {
+		while let Some(key) = map.next_key()? {
 			match key {
-				"order" => {
+				Field::Order => {
 					if self.order.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("order"));
 					}
 				},
-				"head" => {
+				Field::Head => {
 					if self.head.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("head"));
 					}
 				},
-				"bits" => {
+				Field::Bits => {
 					if self.bits.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("bits"));
 					}
 				},
-				"data" => {
+				Field::Data => {
 					if self.data.replace(map.next_value()?).is_some() {
 						return Err(<V::Error>::duplicate_field("data"));
 					}
-				},
-				f => {
-					let _ = map.next_value::<()>();
-					return Err(<V::Error>::unknown_field(f, FIELDS));
 				},
 			}
 		}
@@ -370,16 +361,9 @@ mod tests {
 			&[
 				Token::Seq { len: Some(4) },
 				Token::BorrowedStr(any::type_name::<Lsb0>()),
-				Token::Seq { len: Some(2) },
-				Token::U8(8),
-				Token::U8(1),
-				Token::SeqEnd,
-				Token::U64(9),
-				Token::BorrowedBytes(&[0x3C, 0xA5]),
-				Token::SeqEnd,
 			],
 			&format!(
-				"invalid type: string \"{}\", expected a `BitSlice<u8, {}>`",
+				"invalid value: string \"{}\", expected the string \"{}\"",
 				any::type_name::<Lsb0>(),
 				any::type_name::<Msb0>(),
 			),
@@ -392,8 +376,6 @@ mod tests {
 					len:  1,
 				},
 				Token::BorrowedStr("unknown"),
-				Token::BorrowedStr("field"),
-				Token::StructEnd,
 			],
 			&format!(
 				"unknown field `unknown`, expected one of `{}`",

--- a/src/serdes/utils.rs
+++ b/src/serdes/utils.rs
@@ -45,6 +45,37 @@ use crate::{
 /// Fields used in the `BitIdx` transport format.
 static FIELDS: &[&str] = &["width", "index"];
 
+enum Field {
+	Width,
+	Index,
+}
+
+struct FieldVisitor;
+
+impl<'de> Deserialize<'de> for Field {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where D: Deserializer<'de> {
+		deserializer.deserialize_identifier(FieldVisitor)
+	}
+}
+
+impl<'de> Visitor<'de> for FieldVisitor {
+	type Value = Field;
+
+	fn expecting(&self, fmt: &mut Formatter) -> fmt::Result {
+		fmt.write_str("field identifier")
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+	where E: serde::de::Error {
+		match value {
+			"width" => Ok(Field::Width),
+			"index" => Ok(Field::Index),
+			_ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+		}
+	}
+}
+
 impl<R> Serialize for BitIdx<R>
 where R: BitRegister
 {
@@ -246,21 +277,17 @@ where R: BitRegister
 		let mut width = None;
 		let mut index = None;
 
-		while let Some(key) = map.next_key::<&'de str>()? {
+		while let Some(key) = map.next_key()? {
 			match key {
-				"width" => {
+				Field::Width => {
 					if width.replace(map.next_value::<u8>()?).is_some() {
 						return Err(<V::Error>::duplicate_field("width"));
 					}
 				},
-				"index" => {
+				Field::Index => {
 					if index.replace(map.next_value::<u8>()?).is_some() {
 						return Err(<V::Error>::duplicate_field("index"));
 					}
-				},
-				f => {
-					let _ = map.next_value::<()>();
-					return Err(<V::Error>::unknown_field(f, FIELDS));
 				},
 			}
 		}
@@ -362,8 +389,6 @@ mod tests {
 					len:  1,
 				},
 				Token::BorrowedStr("unknown"),
-				Token::BorrowedStr("field"),
-				Token::StructEnd,
 			],
 			"unknown field `unknown`, expected `width` or `index`",
 		);


### PR DESCRIPTION
Fixes #167.

Bitvec's handwritten `Deserialize` impls tried to borrow a bunch of strings directly from the deserializer's input, including the field names "order", "head", "bits", "data", "width", "index" and the value of the "order" field for comparing against `type_name::<O>()`.

This sometimes works, for example when deserializing from a JSON &amp;str. However, this is not how derived `Deserialize` impls work and a lot of formats won't be able to hand out borrowed data from the input like that. For example, when deserializing any data format from a `R: std::io::Read`. (You can tell because https://doc.rust-lang.org/std/io/trait.Read.html literally has no methods for borrowing data. *Everything* that this trait does is defined in terms of copying data into a caller-provided buffer, not borrowing it from the underlying i/o object.)

This PR changes the `Deserialize` impls to borrow from the `Deserializer` instead, as opposed to the input data. This works efficiently in all formats. Deserializers that operate on i/o resources will let you borrow from the same buffer that they use for obtaining data from the underlying `Read` object. Deserializers that wrap an in-memory data structure like `serde_json::Value` will borrow from there without copying or allocation.